### PR TITLE
Fix food pairing hook export

### DIFF
--- a/src/hooks/useFoodPairingAI.js
+++ b/src/hooks/useFoodPairingAI.js
@@ -1,25 +1,28 @@
 import { useState } from 'react';
 
-export default function useFoodPairingAI() {
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
-  const [response, setResponse] = useState(null);
+export const useFoodPairingAI = (setError) => {
+  const [foodPairingSuggestion, setFoodPairingSuggestion] = useState(null);
+  const [isLoadingPairing, setIsLoadingPairing] = useState(false);
+  const [pairingError, setPairingError] = useState(null);
 
-  const callGeminiProxy = async (food, wineList) => {
-    setLoading(true);
-    setError(null);
-    setResponse(null);
+  const fetchFoodPairing = async (wine) => {
+    if (!wine) {
+      setPairingError('No wine selected for pairing.');
+      return;
+    }
 
-    const prompt = `Given the food item: "${food}", and the following wines from my cellar:\n\n${wineList}\n\nSuggest 1-3 wines from the list that would pair well with "${food}". Focus only on the provided wine list.`;
+    setIsLoadingPairing(true);
+    setPairingError(null);
+    setFoodPairingSuggestion(null);
 
-    console.log('[ReversePairing] 🧠 Prompt:\n', prompt);
+    const { producer, year, region, color, name } = wine;
+    const wineDescription = `${name ? name + ' ' : ''}${producer} ${color} wine from ${region}, year ${year || 'N/A'}`;
+    const prompt = `Suggest a specific food pairing for the following wine: ${wineDescription}. Provide a concise suggestion (1-2 sentences).`;
 
     try {
-      const res = await fetch('/api/gemini', {
+      const response = await fetch('/api/gemini', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           contents: [
             {
@@ -30,21 +33,93 @@ export default function useFoodPairingAI() {
         }),
       });
 
-      if (!res.ok) {
-        const errText = await res.text();
+      if (!response.ok) {
+        const errText = await response.text();
         throw new Error(errText);
       }
 
-      const data = await res.json();
-      const output = data?.candidates?.[0]?.content?.parts?.[0]?.text || 'No response received.';
-      setResponse(output);
+      const data = await response.json();
+      const suggestion = data?.candidates?.[0]?.content?.parts?.[0]?.text;
+      if (suggestion) {
+        setFoodPairingSuggestion(suggestion);
+      } else {
+        setFoodPairingSuggestion('No specific pairing suggestion found.');
+      }
     } catch (err) {
-      console.error('[ReversePairing] ❌ Proxy error:', err);
-      setError(err.message);
+      console.error('Error fetching food pairing:', err);
+      setPairingError(`Food pairing suggestion failed: ${err.message}`);
+      setError((prev) => (prev ? prev + '; ' + err.message : err.message));
     } finally {
-      setLoading(false);
+      setIsLoadingPairing(false);
     }
   };
 
-  return { callGeminiProxy, response, loading, error };
-}
+  const findWineForFood = async (foodItem, wines) => {
+    if (!foodItem.trim()) {
+      setPairingError('Please enter a food item to find a wine pairing.');
+      return;
+    }
+    if (!wines || wines.length === 0) {
+      setPairingError('Your cellar is empty. Add some wines first to find a pairing.');
+      return;
+    }
+
+    setIsLoadingPairing(true);
+    setPairingError(null);
+    setFoodPairingSuggestion(null);
+
+    const wineListText = wines
+      .map(
+        (wine, idx) =>
+          `${idx + 1}. Name: ${wine.name || 'N/A'}, Producer: ${wine.producer}, Color: ${wine.color}, Region: ${wine.region}, Year: ${wine.year || 'N/A'}`,
+      )
+      .join('\n');
+
+    const prompt = `I want to eat "${foodItem}". From the following list of wines in my cellar, which one would be the BEST match? Also, list up to two other good alternatives if any. For each suggested wine, briefly explain your choice. If no wines are a good match, please state that.\nMy wines are:\n${wineListText}`;
+
+    try {
+      const response = await fetch('/api/gemini', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contents: [
+            {
+              role: 'user',
+              parts: [{ text: prompt }],
+            },
+          ],
+        }),
+      });
+
+      if (!response.ok) {
+        const errText = await response.text();
+        throw new Error(errText);
+      }
+
+      const data = await response.json();
+      const suggestion = data?.candidates?.[0]?.content?.parts?.[0]?.text;
+      if (suggestion) {
+        setFoodPairingSuggestion(suggestion);
+      } else {
+        setFoodPairingSuggestion('No specific reverse pairing suggestion found.');
+      }
+    } catch (err) {
+      console.error('Error finding wine for food:', err);
+      setPairingError(`Finding wine for food failed: ${err.message}`);
+      setError((prev) => (prev ? prev + '; ' + err.message : err.message));
+    } finally {
+      setIsLoadingPairing(false);
+    }
+  };
+
+  return {
+    foodPairingSuggestion,
+    isLoadingPairing,
+    pairingError,
+    fetchFoodPairing,
+    findWineForFood,
+    setFoodPairingSuggestion,
+    setPairingError,
+  };
+};
+


### PR DESCRIPTION
## Summary
- restore `useFoodPairingAI` as a named export
- keep previous functionality while using the `/api/gemini` proxy

## Testing
- `npm ci` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6873f1fb0f3c83309e62f306093a2473