### PR TITLE
Fix Gemini Flash proxy to use v1beta endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -38,7 +38,7 @@ app.post('/api/gemini', async (req, res) => {
   }
 
   try {
-    const response = await fetchFn(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${GEMINI_API_KEY}`, {
+    const response = await fetchFn(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${GEMINI_API_KEY}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/src/pages/api/gemini.js
+++ b/src/pages/api/gemini.js
@@ -9,7 +9,9 @@ export default async function handler(req, res) {
     return res.status(500).json({ error: 'Missing Gemini API key in environment variables.' });
   }
 
-  const geminiUrl = `https://generativelanguage.googleapis.com/v1/models/gemini-1.5-flash:generateContent?key=${apiKey}`;
+  // The Gemini Flash 1.5 model is only available on the v1beta API.
+  // Using the latest alias keeps the integration working as Google retires specific revisions.
+  const geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`;
 
   try {
     const geminiRes = await fetch(geminiUrl, {


### PR DESCRIPTION
## Summary
- update the Next.js Gemini proxy to call the v1beta Flash endpoint with the latest alias
- align the Express proxy with the same endpoint to avoid 404 errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5164a30888330a6406de12e3eb7f2