### PR TITLE
Set Gemini defaults to gemini-2.5-flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The AI pairing features depend on Google AI Studio's Gemini API.
 
 1. Set the required environment variable `GEMINI_API_KEY` in both the frontend (Next.js API route) and in the optional Express proxy (`server.js`).
 2. (Optional) Override the defaults via:
-   - `GEMINI_MODEL` (defaults to `gemini-1.5-flash-latest`)
+   - `GEMINI_MODEL` (defaults to `models/gemini-2.5-flash`)
    - `GEMINI_API_VERSION` (defaults to `v1beta`)
    - `GEMINI_API_BASE_URL` (defaults to `https://generativelanguage.googleapis.com`)
 

--- a/server.js
+++ b/server.js
@@ -26,7 +26,6 @@ const PORT = process.env.PORT || 5001;
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 const GEMINI_API_VERSION = process.env.GEMINI_API_VERSION || 'v1beta';
 const GEMINI_BASE_URL = (process.env.GEMINI_API_BASE_URL || 'https://generativelanguage.googleapis.com').replace(/\/$/, '');
-const DEFAULT_MODEL = process.env.GEMINI_MODEL || 'gemini-1.5-flash-latest';
 
 const normaliseModel = (model) => {
   if (!model || typeof model !== 'string') {
@@ -35,6 +34,8 @@ const normaliseModel = (model) => {
 
   return model.startsWith('models/') ? model.slice('models/'.length) : model;
 };
+
+const DEFAULT_MODEL = normaliseModel(process.env.GEMINI_MODEL) || 'gemini-2.5-flash';
 
 const buildGeminiUrl = (model, apiKey) =>
   `${GEMINI_BASE_URL}/${GEMINI_API_VERSION}/models/${model}:generateContent?key=${apiKey}`;

--- a/src/pages/api/gemini.js
+++ b/src/pages/api/gemini.js
@@ -1,4 +1,3 @@
-const DEFAULT_MODEL = process.env.GEMINI_MODEL || 'gemini-1.5-flash-latest';
 const API_VERSION = process.env.GEMINI_API_VERSION || 'v1beta';
 const API_BASE_URL = (process.env.GEMINI_API_BASE_URL || 'https://generativelanguage.googleapis.com').replace(/\/$/, '');
 
@@ -9,6 +8,8 @@ const normaliseModel = (model) => {
 
   return model.startsWith('models/') ? model.slice('models/'.length) : model;
 };
+
+const DEFAULT_MODEL = normaliseModel(process.env.GEMINI_MODEL) || 'gemini-2.5-flash';
 
 const buildGeminiUrl = (model, apiKey) =>
   `${API_BASE_URL}/${API_VERSION}/models/${model}:generateContent?key=${apiKey}`;


### PR DESCRIPTION
## Summary
- normalize configured Gemini model names and default to gemini-2.5-flash in both API layers
- document the updated default model in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e53330320c83309c0549f5b13beac1