### PR TITLE
Retry Gemini requests with default model fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ The AI pairing features depend on Google AI Studio's Gemini API.
 
 1. Set the required environment variable `GEMINI_API_KEY` in both the frontend (Next.js API route) and in the optional Express proxy (`server.js`).
 2. (Optional) Override the defaults via:
-   - `GEMINI_MODEL` (defaults to `gemini-1.5-flash-latest`)
+   - `GEMINI_MODEL` (defaults to `models/gemini-2.5-flash`)
    - `GEMINI_API_VERSION` (defaults to `v1beta`)
    - `GEMINI_API_BASE_URL` (defaults to `https://generativelanguage.googleapis.com`)
 
-When the Gemini API responds with `404 NOT_FOUND`, the proxy automatically asks Google for the list of available models and returns them in the `availableModels` field. Use that response to pick a supported model/version combination and update your `.env` settings accordingly.
+If a request references a retired model, the proxy will transparently retry with the default `models/gemini-2.5-flash` model and include `x-gemini-model-used` (plus `x-gemini-model-fallback` when applicable) headers so you can confirm which model ultimately served the response.
+
+When the Gemini API responds with `404 NOT_FOUND`, the proxy automatically asks Google for the list of available models and returns them in the `availableModels` field alongside the `attemptedModels` that failed. Use that response to pick a supported model/version combination and update your `.env` settings accordingly.
 
 ## Available Scripts
 

--- a/src/pages/api/gemini.js
+++ b/src/pages/api/gemini.js
@@ -1,4 +1,3 @@
-const DEFAULT_MODEL = process.env.GEMINI_MODEL || 'gemini-1.5-flash-latest';
 const API_VERSION = process.env.GEMINI_API_VERSION || 'v1beta';
 const API_BASE_URL = (process.env.GEMINI_API_BASE_URL || 'https://generativelanguage.googleapis.com').replace(/\/$/, '');
 
@@ -9,6 +8,8 @@ const normaliseModel = (model) => {
 
   return model.startsWith('models/') ? model.slice('models/'.length) : model;
 };
+
+const DEFAULT_MODEL = normaliseModel(process.env.GEMINI_MODEL) || 'gemini-2.5-flash';
 
 const buildGeminiUrl = (model, apiKey) =>
   `${API_BASE_URL}/${API_VERSION}/models/${model}:generateContent?key=${apiKey}`;
@@ -43,37 +44,97 @@ export default async function handler(req, res) {
   const requestedModel = normaliseModel(requestBody.model);
   const model = requestedModel || DEFAULT_MODEL;
 
-  const payload = {
-    ...requestBody,
-    model: `models/${model}`,
-  };
+  const { model: _ignoredModel, ...restRequestBody } = requestBody;
+  const buildPayloadForModel = (modelName) => ({
+    ...restRequestBody,
+    model: `models/${modelName}`,
+  });
 
-  const geminiUrl = buildGeminiUrl(model, apiKey);
-
-  try {
-    const geminiRes = await fetch(geminiUrl, {
+  const attemptGeminiCall = async (modelName) => {
+    const response = await fetch(buildGeminiUrl(modelName, apiKey), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(payload),
+      body: JSON.stringify(buildPayloadForModel(modelName)),
     });
 
-    if (!geminiRes.ok) {
-      if (geminiRes.status === 404) {
+    const rawText = await response.text();
+    let parsed;
+    try {
+      parsed = rawText ? JSON.parse(rawText) : null;
+    } catch (error) {
+      parsed = null;
+    }
+
+    return {
+      response,
+      parsed,
+      rawText,
+      modelName,
+    };
+  };
+
+  try {
+    const primaryAttempt = await attemptGeminiCall(model);
+
+    if (primaryAttempt.response.ok) {
+      res.setHeader('x-gemini-model-used', primaryAttempt.modelName);
+      return res.status(200).json(primaryAttempt.parsed || {});
+    }
+
+    const attemptedModels = [primaryAttempt.modelName];
+
+    if (primaryAttempt.response.status === 404 && primaryAttempt.modelName !== DEFAULT_MODEL) {
+      const fallbackAttempt = await attemptGeminiCall(DEFAULT_MODEL);
+      attemptedModels.push(DEFAULT_MODEL);
+
+      if (fallbackAttempt.response.ok) {
+        res.setHeader('x-gemini-model-used', fallbackAttempt.modelName);
+        res.setHeader('x-gemini-model-fallback', primaryAttempt.modelName);
+        return res.status(200).json(fallbackAttempt.parsed || {});
+      }
+
+      if (fallbackAttempt.response.status === 404) {
         const availableModels = await fetchAvailableModels(apiKey);
         return res.status(404).json({
-          error: `Gemini API Error: Model "${model}" is not available for API version "${API_VERSION}" at ${API_BASE_URL}.`,
+          error: `Gemini API Error: Requested models ${attemptedModels
+            .map((name) => `"${name}"`)
+            .join(', ')} are not available for API version "${API_VERSION}" at ${API_BASE_URL}.`,
           availableModels,
+          attemptedModels,
+          rawError: fallbackAttempt.parsed || fallbackAttempt.rawText || null,
         });
       }
 
-      const errorText = await geminiRes.text();
-      return res.status(geminiRes.status).json({ error: `Gemini API Error: ${errorText}` });
+      return res.status(fallbackAttempt.response.status).json({
+        error:
+          fallbackAttempt.parsed?.error?.message ||
+          fallbackAttempt.parsed?.error ||
+          fallbackAttempt.rawText ||
+          `Gemini API Error (HTTP ${fallbackAttempt.response.status}).`,
+        attemptedModels,
+      });
     }
 
-    const data = await geminiRes.json();
-    return res.status(200).json(data);
+    if (primaryAttempt.response.status === 404) {
+      const availableModels = await fetchAvailableModels(apiKey);
+      return res.status(404).json({
+        error: `Gemini API Error: Model "${primaryAttempt.modelName}" is not available for API version "${API_VERSION}" at ${API_BASE_URL}.`,
+        availableModels,
+        attemptedModels,
+        rawError: primaryAttempt.parsed || primaryAttempt.rawText || null,
+      });
+    }
+
+    return res.status(primaryAttempt.response.status).json({
+      error:
+        primaryAttempt.parsed?.error?.message ||
+        primaryAttempt.parsed?.error ||
+        primaryAttempt.rawText ||
+        `Gemini API Error (HTTP ${primaryAttempt.response.status}).`,
+      attemptedModels,
+    });
   } catch (err) {
     return res.status(500).json({ error: `Proxy Error: ${err.message}` });
   }


### PR DESCRIPTION
## Summary
- retry Gemini generateContent calls with the default models/gemini-2.5-flash model when a requested model returns 404
- surface attempted models, fallback headers, and richer error payloads from both the Next.js and Express proxies
- document the automatic fallback behaviour and new response metadata in the Gemini configuration section

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e53330320c83309c0549f5b13beac1