### PR TITLE
Sanitize model names for OpenAI proxy

### DIFF
--- a/server.js
+++ b/server.js
@@ -33,6 +33,28 @@ const CHAT_COMPLETIONS_PATH = process.env.OPENAI_CHAT_COMPLETIONS_PATH || '/v1/c
 const buildCompletionsUrl = () =>
   `${OPENAI_BASE_URL}${CHAT_COMPLETIONS_PATH.startsWith('/') ? '' : '/'}${CHAT_COMPLETIONS_PATH}`;
 
+const shouldIgnoreRequestedModel = (model) => {
+  if (typeof model !== 'string') {
+    return true;
+  }
+
+  const trimmed = model.trim();
+
+  if (!trimmed) {
+    return true;
+  }
+
+  return /^models\//.test(trimmed) || trimmed.includes(':');
+};
+
+const resolveModel = (model) => {
+  if (!shouldIgnoreRequestedModel(model)) {
+    return model.trim();
+  }
+
+  return OPENAI_MODEL;
+};
+
 const normaliseMessages = (body) => {
   if (!body || typeof body !== 'object') {
     return null;
@@ -113,7 +135,7 @@ app.post('/api/openai', async (req, res) => {
 
   const payload = {
     ...restBody,
-    model: requestedModel || OPENAI_MODEL,
+    model: resolveModel(requestedModel),
     messages,
   };
 

--- a/src/pages/api/openai.js
+++ b/src/pages/api/openai.js
@@ -2,6 +2,28 @@ const API_BASE_URL = (process.env.OPENAI_API_BASE_URL || 'https://api.openai.com
 const CHAT_COMPLETIONS_PATH = process.env.OPENAI_CHAT_COMPLETIONS_PATH || '/v1/chat/completions';
 const DEFAULT_MODEL = process.env.OPENAI_MODEL || 'gpt-4o-mini';
 
+const shouldIgnoreRequestedModel = (model) => {
+  if (typeof model !== 'string') {
+    return true;
+  }
+
+  const trimmed = model.trim();
+
+  if (!trimmed) {
+    return true;
+  }
+
+  return /^models\//.test(trimmed) || trimmed.includes(':');
+};
+
+const resolveModel = (requestedModel) => {
+  if (!shouldIgnoreRequestedModel(requestedModel)) {
+    return requestedModel.trim();
+  }
+
+  return DEFAULT_MODEL;
+};
+
 const normaliseMessages = (requestBody) => {
   if (!requestBody || typeof requestBody !== 'object') {
     return null;
@@ -87,7 +109,7 @@ export default async function handler(req, res) {
 
   const payload = {
     ...rest,
-    model: requestedModel || DEFAULT_MODEL,
+    model: resolveModel(requestedModel),
     messages,
   };
 


### PR DESCRIPTION
## Summary
- ignore legacy Gemini model identifiers when relaying requests through the OpenAI proxy
- fall back to the configured OpenAI model when an invalid or empty model name is provided

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6816035588330aa30b60aa2dd77e7